### PR TITLE
GSoC 2019 - dependency version updates, bug fix and deprecation warning fix

### DIFF
--- a/debian/dependencies/tasks/main.yml
+++ b/debian/dependencies/tasks/main.yml
@@ -2,14 +2,14 @@
 - include: base-packages.yml
 
 - name: Create SRC direcrtory
-  when: packagesinstalled|success
+  when: packagesinstalled is success
   file: dest={{srcdir}} mode=775 state=directory owner=www-data group=www-data
   register: srcdircreated
 
 - include: r-cran.yml
 
 - name: Download MapMint
-  when: srcdircreated|success
+  when: srcdircreated is success
   git: repo=https://github.com/mapmint/mapmint.git
        dest={{srcdir}}/mapmint
        force=yes

--- a/debian/dependencies/tasks/mapcache.yml
+++ b/debian/dependencies/tasks/mapcache.yml
@@ -1,6 +1,6 @@
 ---
 - name: Download MapCache
-  when: mapserverinstalled|success
+  when: mapserverinstalled is success
   git: repo=https://github.com/mapserver/mapcache.git
        dest={{srcdir}}/mapcache
   register: mapcachedownloaded
@@ -8,7 +8,7 @@
 - copy: src=dependencies/files/etc/ld.so.conf.d/zoo-project.conf dest=/etc/ld.so.conf.d/zoo-project.conf
 
 - name: Build and Install MapCache
-  when: mapcachedownloaded|success
+  when: mapcachedownloaded is success
   shell: cd {{srcdir}}/mapcache/ ; cmake . && make && make install && cp /usr/local/bin/mapcache.fcgi /usr/lib/cgi-bin/mm/
   notify:
     - Update ldconfig

--- a/debian/dependencies/tasks/mapserver.yml
+++ b/debian/dependencies/tasks/mapserver.yml
@@ -3,6 +3,6 @@
   get_url: url=http://download.osgeo.org/mapserver/mapserver-6.2.0.tar.gz dest={{srcdir}}/mapserver-6.2.0.tar.gz
 
 - name: Build and Install MapServer-6.2.0 for MapMint
-  when: srcdircreated|success
+  when: srcdircreated is success
   shell: cd {{srcdir}} && tar -xf mapserver-6.2.0.tar.gz && cd mapserver-6.2.0 && ./configure --with-wfs --with-python --with-freetype=/usr/ --with-ogr --with-gdal --with-proj --with-geos --with-cairo --with-kml --with-wmsclient --with-wfsclient --with-wcs --with-sos --with-python=/usr/bin/python2.7 --without-gif --with-apache-module --with-apxs=/usr/bin/apxs2 --with-apr-config=/usr/bin/apr-1-config --enable-python-mapscript --with-zlib --prefix=/usr/ && sed "s:mapserver-6.2.0-mm/::g;s:mapserver-6.2.0/::g" -i ../mapmint/thirds/ms-6.2.0-full.patch && patch -p0 < ../mapmint/thirds/ms-6.2.0-full.patch && make && make install && cp /usr/bin/mapserv /usr/lib/cgi-bin/mm/mapserv.cgi
   register: mapserverinstalled

--- a/debian/mapmint/tasks/main.yml
+++ b/debian/mapmint/tasks/main.yml
@@ -8,22 +8,22 @@
   register: zookdownloaded
 
 - name: Build and Install ZOO-Kernel from ZOO-Project
-  when: zookdownloaded|success
+  when: zookdownloaded is success
   shell: cd {{srcdir}}/zoo/thirds/cgic206 && sed "s:lib64:lib:g" -i Makefile && make && cd {{srcdir}}/zoo/zoo-project/zoo-kernel && autoconf && ./configure --with-mapserver={{srcdir}}/mapserver-6.2.0/ --with-python --with-pyvers=2.7 --with-js=/usr/ --with-xsltconfig=/usr/bin/xslt-config &&  sed "s:/usr/lib/x86_64-linux-gnu/libapr-1.la::g;s:/usr/lib/i386-linux-gnu/libapr-1.la::g" -i ZOOMakefile.opts && make &&  make install &&  ldconfig && cp zoo_loader.cgi ../../../mapmint/mapmint-services/
   register: zookinstalled
 
 - name: Build and Install GetStatus ZOO-Services from ZOO-Project
-  when: zookinstalled|success
+  when: zookinstalled is success
   shell: cd {{srcdir}}/zoo/zoo-project/zoo-services/utils/status && make && cp cgi-env/* {{srcdir}}/mapmint/mapmint-services/ 
   register: zooostatusinstalled
 
 - name: Build and Install OGR ZOO-Services from ZOO-Project
-  when: zookinstalled|success
+  when: zookinstalled is success
   shell: cd {{srcdir}}/zoo/zoo-project/zoo-services/ogr && cd ogr2ogr && make && cp cgi-env/* {{srcdir}}/mapmint/mapmint-services/vector-converter/ && cd .. && cd base-vect-ops && make && cp cgi-env/* {{srcdir}}/mapmint/mapmint-services/vector-tools/
   register: zooosinstalled
 
 - name: Build and Install GDAL ZOO-Services from ZOO-Project
-  when: zooosinstalled|success
+  when: zooosinstalled is success
   shell: cd {{srcdir}}/zoo/zoo-project/zoo-services/gdal && for i in contour dem grid profile translate warp ; do echo $i ; cd $i ; make; cp cgi-env/* {{srcdir}}/mapmint/mapmint-services/raster-tools/ ; cd .. ; done
   register: zoogsinstalled
 
@@ -39,12 +39,12 @@
   register: qrlibinstalled
 
 - name: Build and Install QREncode ZOO-Services from ZOO-Project
-  when: qrlibinstalled|success
+  when: qrlibinstalled is success
   shell: cd {{srcdir}}/zoo/zoo-project/zoo-services/qrencode && make; cp cgi-env/* {{srcdir}}/mapmint/mapmint-services/ ; cd .. ;
   register: zooqsinstalled
 
 - name: Build MapMint C ZOO-Services
-  when: zooqsinstalled|success
+  when: zooqsinstalled is success
   shell: cd {{srcdir}}/mapmint/mapmint-services; for i in *-src ; do echo $i; cd $i; autoconf; ./configure --with-zoo-kernel={{srcdir}}/zoo/zoo-project/zoo-kernel --with-mapserver={{srcdir}}/mapserver-6.2.0 ; make ; cd .. ; done
   register: zoomcsinstalled
 
@@ -98,7 +98,7 @@
     - Reload PostgreSQL
 
 - name: Create initial PG Database
-  when: pgrestarted|success
+  when: pgrestarted is success
   shell: export PGUSER=postgres; psql mmdb -f {{srcdir}}/mapmint/template/sql/mmdb.sql && psql mmdb -f {{srcdir}}/mapmint/template/sql/indicators.sql && psql mmdb -f {{srcdir}}/mapmint/template/sql/tables.sql
 
 

--- a/osgeolive/dependencies/tasks/main.yml
+++ b/osgeolive/dependencies/tasks/main.yml
@@ -2,14 +2,14 @@
 - include: base-packages.yml
 
 - name: Create SRC direcrtory
-  when: packagesinstalled|success
+  when: packagesinstalled is success
   file: dest={{srcdir}} mode=775 state=directory owner=www-data group=www-data
   register: srcdircreated
 
 - include: r-cran.yml
 
 - name: Download MapMint
-  when: srcdircreated|success
+  when: srcdircreated is success
   git: repo=https://github.com/mapmint/mapmint.git
        dest={{srcdir}}/mapmint
        force=yes

--- a/osgeolive/dependencies/tasks/mapcache.yml
+++ b/osgeolive/dependencies/tasks/mapcache.yml
@@ -1,6 +1,6 @@
 ---
 - name: Download MapCache
-#  when: mapserverinstalled|success
+#  when: mapserverinstalled is success
   git: repo=https://github.com/mapserver/mapcache.git
        dest={{srcdir}}/mapcache
   register: mapcachedownloaded
@@ -8,7 +8,7 @@
 - copy: src=dependencies/files/etc/ld.so.conf.d/zoo-project.conf dest=/etc/ld.so.conf.d/zoo-project.conf
 
 - name: Build and Install MapCache
-  when: mapcachedownloaded|success
+  when: mapcachedownloaded is success
   shell: cd {{srcdir}}/mapcache/ ; cmake . && make && make install && cp /usr/local/bin/mapcache.fcgi /usr/lib/cgi-bin/mm/
   notify:
     - Update ldconfig

--- a/osgeolive/dependencies/tasks/mapserver.yml
+++ b/osgeolive/dependencies/tasks/mapserver.yml
@@ -3,6 +3,6 @@
   get_url: url=http://download.osgeo.org/mapserver/mapserver-7.2.1.tar.gz dest={{srcdir}}/mapserver-7.2.1.tar.gz
 
 - name: Build and Install MapServer-7.2.1 for MapMint
-  when: srcdircreated|success
+  when: srcdircreated is success
   shell: cd {{srcdir}} && tar -xf mapserver-7.2.1.tar.gz && cd mapserver-7.2.1 && rm -rf build && mkdir build && cd build && cmake .. -DWITH_PYTHON=1 -DWITH_CLIENT_WMS=1 -DWITH_CLIENT_WFS=1 -DCMAKE_PREFIX_PATH=/usr/ -DWITH_KML=1 -DCMAKE_INSTALL_PREFIX=/usr && make && make install
   register: mapserverinstalled

--- a/osgeolive/dependencies/tasks/mapserver.yml
+++ b/osgeolive/dependencies/tasks/mapserver.yml
@@ -4,5 +4,5 @@
 
 - name: Build and Install MapServer-7.2.1 for MapMint
   when: srcdircreated|success
-  shell: cd {{srcdir}} && tar -xf mapserver-7.2.1.tar.gz && cd mapserver-7.2.1 && mkdir build && cd build && cmake .. -DWITH_PYTHON=1 -DWITH_CLIENT_WMS=1 -DWITH_CLIENT_WFS=1 -DCMAKE_PREFIX_PATH=/usr/ -DWITH_KML=1 -DCMAKE_INSTALL_PREFIX=/usr && make && make install
+  shell: cd {{srcdir}} && tar -xf mapserver-7.2.1.tar.gz && cd mapserver-7.2.1 && rm -rf build && mkdir build && cd build && cmake .. -DWITH_PYTHON=1 -DWITH_CLIENT_WMS=1 -DWITH_CLIENT_WFS=1 -DCMAKE_PREFIX_PATH=/usr/ -DWITH_KML=1 -DCMAKE_INSTALL_PREFIX=/usr && make && make install
   register: mapserverinstalled

--- a/osgeolive/dependencies/tasks/r-cran.yml
+++ b/osgeolive/dependencies/tasks/r-cran.yml
@@ -2,12 +2,12 @@
 - name: Download r-cran packages
   get_url: url=https://cran.r-project.org/src/contrib/{{item}} dest={{srcdir}}/{{item}}
   with_items:
-      - e1071_1.7-1.tar.gz
-      - classInt_0.3-1.tar.gz
+      - e1071_1.7-2.tar.gz
+      - classInt_0.3-3.tar.gz
 
 - name: Install r-cran packages
   shell: cd {{srcdir}}; R CMD INSTALL {{item}}
   with_items:
-      - e1071_1.7-1.tar.gz
-      - classInt_0.3-1.tar.gz
+      - e1071_1.7-2.tar.gz
+      - classInt_0.3-3.tar.gz
 

--- a/osgeolive/dependencies/vars/main.yml
+++ b/osgeolive/dependencies/vars/main.yml
@@ -6,6 +6,6 @@ rootdir: /var/www/html
 pgvers: 10
 pgisvers: 2.4
 indicators: false
-lo_version: 6.0.7
+lo_version: 6.2.5
 arch: x86_64
 larch: x86-64

--- a/osgeolive/mapmint/tasks/main.yml
+++ b/osgeolive/mapmint/tasks/main.yml
@@ -103,7 +103,7 @@
   shell: export PGUSER=postgres; psql mmdb -f {{srcdir}}/mapmint/template/sql/mmdb.sql && psql mmdb -f {{srcdir}}/mapmint/template/sql/indicators.sql && psql mmdb -f {{srcdir}}/mapmint/template/sql/tables.sql
 
 
-- shell: rm /var/www/html/tmp
+- shell: rm -rf /var/www/html/tmp
 
 
 - name: Create MapMint data directories

--- a/osgeolive/mapmint/tasks/main.yml
+++ b/osgeolive/mapmint/tasks/main.yml
@@ -9,22 +9,22 @@
   register: zookdownloaded
 
 - name: Build and Install ZOO-Kernel from ZOO-Project
-  when: zookdownloaded|success
+  when: zookdownloaded is success
   shell: cd {{srcdir}}/zoo/thirds/cgic206 && sed "s:lib64:lib:g" -i Makefile && make libcgic.a && cd {{srcdir}}/zoo/zoo-project/zoo-kernel && autoconf && ./configure --with-mapserver=/usr/ --with-ms-version=7 --with-python --with-pyvers=2.7 --with-js=/usr/ --with-xsltconfig=/usr/bin/xslt-config &&  sed "s:/usr/lib/x86_64-linux-gnu/libapr-1.la::g;s:/usr/lib/i386-linux-gnu/libapr-1.la::g;s:-lintl::g;s:-DUSE_MS   -I/usr/include:-DUSE_MS   -I/usr/include/mapserver:g" -i ZOOMakefile.opts && make &&  make install &&  ldconfig && cp zoo_loader.cgi ../../../mapmint/mapmint-services/
   register: zookinstalled
 
 - name: Build and Install GetStatus ZOO-Services from ZOO-Project
-  when: zookinstalled|success
+  when: zookinstalled is success
   shell: cd {{srcdir}}/zoo/zoo-project/zoo-services/utils/status && make && cp cgi-env/* {{srcdir}}/mapmint/mapmint-services/ 
   register: zooostatusinstalled
 
 - name: Build and Install OGR ZOO-Services from ZOO-Project
-  when: zookinstalled|success
+  when: zookinstalled is success
   shell: cd {{srcdir}}/zoo/zoo-project/zoo-services/ogr && cd ogr2ogr && sed "s:free(pszDialect:free((void*)pszDialect:g" -i service.c && make && cp cgi-env/* {{srcdir}}/mapmint/mapmint-services/vector-converter/ && cd .. && cd base-vect-ops && make && cp cgi-env/* {{srcdir}}/mapmint/mapmint-services/vector-tools/
   register: zooosinstalled
 
 - name: Build and Install GDAL ZOO-Services from ZOO-Project
-  when: zooosinstalled|success
+  when: zooosinstalled is success
   shell: cd {{srcdir}}/zoo/zoo-project/zoo-services/gdal && for i in contour dem grid profile translate warp ; do echo $i ; cd $i ; make; cp cgi-env/* {{srcdir}}/mapmint/mapmint-services/raster-tools/ ; cd .. ; done
   register: zoogsinstalled
 
@@ -40,12 +40,12 @@
   register: qrlibinstalled
 
 - name: Build and Install QREncode ZOO-Services from ZOO-Project
-  when: qrlibinstalled|success
+  when: qrlibinstalled is success
   shell: cd {{srcdir}}/zoo/zoo-project/zoo-services/qrencode && make; cp cgi-env/* {{srcdir}}/mapmint/mapmint-services/ ; cd .. ;
   register: zooqsinstalled
 
 - name: Build MapMint C ZOO-Services
-  when: zooqsinstalled|success
+  when: zooqsinstalled is success
   shell: cd {{srcdir}}/mapmint/mapmint-services; for i in *-src ; do echo $i; cd $i; autoconf; ./configure --with-zoo-kernel={{srcdir}}/zoo/zoo-project/zoo-kernel --with-mapserver={{srcdir}}/mapserver-6.2.0 ; make ; cd .. ; done
   register: zoomcsinstalled
 
@@ -99,7 +99,7 @@
     - Reload PostgreSQL
 
 - name: Create initial PG Database
-  when: pgrestarted|success
+  when: pgrestarted is success
   shell: export PGUSER=postgres; psql mmdb -f {{srcdir}}/mapmint/template/sql/mmdb.sql && psql mmdb -f {{srcdir}}/mapmint/template/sql/indicators.sql && psql mmdb -f {{srcdir}}/mapmint/template/sql/tables.sql
 
 


### PR DESCRIPTION
Change summary:
- LibreOffice version(lo_version) updated from v6.0.7 to v6.2.5 as older version is not available for use.
- r-cran package versions updated as older versions are not available.
	* e1071_1.7-1  --->  e1071_1.7-2
	* classInt_0.3-1  --->  classInt_0.3-3
- Ansible deprecation warning fixed since tests as filters will be removed in Ansible v2.9
- If ansible-roles is used more than once, then old build results have to be deleted.
- Folder ```/var/www/html/tmp``` deletion error resolved.