### PR TITLE
GSoC 2019 - update and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ through ssh, the host where to deploy the MapMint instance.
 ```sh
 cd osgeolive
 
+# NOTE: python v3.6.7 or higher required
 pip3 install beautifulsoup4
 python3 "update_r-cran_version.py"
 python3 "update_lo_version.py"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ through ssh, the host where to deploy the MapMint instance.
 
 ```sh
 cd osgeolive
-python "update_r-cran_version.py"
+
+pip3 install beautifulsoup4
+python3 "update_r-cran_version.py"
+python3 "update_lo_version.py"
+
 ansible-playbook -s server.yml -u root
 ```

--- a/osgeolive/update_lo_version.py
+++ b/osgeolive/update_lo_version.py
@@ -1,0 +1,35 @@
+from bs4 import BeautifulSoup
+import requests
+import re
+import os
+print("STATUS: import complete")
+
+url = 'http://download.documentfoundation.org/libreoffice/stable/'
+ext = 'tar.gz'
+
+def listFD(url, ext=''):
+    page = requests.get(url).text
+    # print(page)
+    soup = BeautifulSoup(page, 'html.parser')
+    return [url + '/' + node.get('href') for node in soup.find_all('a') if node.get('href').endswith(ext)]
+
+print("STATUS: loading data from the server url")
+res = listFD(url, '')
+res_list = []
+for i in res:
+    if re.match(r".*[0-9]+\.[0-9]+\.[0-9]+/$", i):
+        res_list.append(i)
+
+final_ver1 = res_list[-1]
+final_ver2 = final_ver1[final_ver1.rfind(r"//") + 2:-1]
+print(f"STATUS: lo_version = {final_ver2}")
+
+print()
+file_path = r"dependencies/vars/main.yml"
+old_lo_version = r"lo_version: 6.2.5"
+new_lo_version = rf"lo_version: {final_ver2}"
+
+os.system(f'sed --in-place "s/{old_lo_version}/{new_lo_version}/g" {file_path}')
+
+print("STATUS: successfully updated the versions :)")
+print(f"{old_lo_version}   --->   {new_lo_version}")

--- a/osgeolive/update_r-cran_version.py
+++ b/osgeolive/update_r-cran_version.py
@@ -28,7 +28,7 @@ for file in res:
 print(f"STATUS:\n\t{res_e_ver}\n\t{res_class_int}")
 
 old_e_ver = "      - e1071_1.7-2.tar.gz"
-old_classInt = "      - classInt_0.3-3.tar.gz"
+old_classInt = "      - classInt_0.4-1.tar.gz"
 new_e_ver = f"      - {res_e_ver}"
 new_classInt = f"      - {res_class_int}"
 file_path = r"dependencies/tasks/r-cran.yml"


### PR DESCRIPTION
Summary:
1. Add python script to automatically update LibreOffice version(lo_version)
2. Fix r-cran python script to replace "classInt_0.4-1.tar.gz" instead of "classInt_0.3-3.tar.gz"
3. Update README.md file to include the new changes and add note for minimum python version (i.e. v3.6.7) requirement.